### PR TITLE
chore: Ignore system files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,10 @@ dist
 .temp
 .cache
 
+# System Files
+.DS_Store
+Thumbs.db
+
 # Docusaurus cache and generated files
 .docusaurus
 


### PR DESCRIPTION
The commit adds the entries for system files `.DS_Store` and `Thumbs.db` to the `.gitignore` file. This ensures that these files are not tracked by Git.